### PR TITLE
Update Readme for react-native version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # react-native-prompt-android
 A polyfill library for Alert.prompt on Android platform, working both on Android and iOS platform(iOS using [AlertIOS.prompt](http://facebook.github.io/react-native/docs/alertios.html#prompt))
 
+Version 1.x recommends react-native >= 0.60.0 for Android 64bit builds and Android X support.
 
 ### Installation
 


### PR DESCRIPTION
Awesome package!
I've added note in README for required react-native version, since the v1.0.0 build seemed to fail in project that is using React Native 0.59. 
Build for older version worked fine in 0.59.